### PR TITLE
fix: the 'world' param can be encoded

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -87,7 +87,7 @@ class Client extends net.Socket {
             };
         });
         const chatEvent = {
-            world,
+            world: Buffer.from(world, 'base64').toString('utf-8'),
             world_display: Buffer.from(world_display, 'base64').toString('utf-8'),
             sender: Buffer.from(sender, 'base64').toString('utf-8'),
             content: decodedContent,

--- a/src/server.ts
+++ b/src/server.ts
@@ -158,7 +158,7 @@ class MyServer extends net.Server {
             };
         });
         const chatEvent: SendChatMessage = {
-            world,
+            world: Buffer.from(world, 'base64').toString('utf-8'),
             world_display: Buffer.from(world_display, 'base64').toString('utf-8'),
             sender: Buffer.from(sender, 'base64').toString('utf-8'),
             content: decodedContent


### PR DESCRIPTION
According to the document,'world' param seemed to be original.Hoever,the actual behavior shows that it can be encoded.I have made changes to adopt this.